### PR TITLE
Fixed bug with kill_port_9999 bash script

### DIFF
--- a/bash/kill_port_9999
+++ b/bash/kill_port_9999
@@ -1,3 +1,3 @@
 #!/bin/bash
 #script to kill all programs using port 9999 (Blazegraph in particular). Use with caution.
-kill -9 `lsof -t -i TCP:9999 -c java`
+kill -9 `lsof -t -i TCP:9999 -c java -a`


### PR DESCRIPTION
Original bash script would have shut down ALL running Java applications if used.