### PR TITLE
Structure

### DIFF
--- a/venv/lib/python2.7/site-packages/superphy/shared/endpoint.py
+++ b/venv/lib/python2.7/site-packages/superphy/shared/endpoint.py
@@ -39,25 +39,8 @@ def update(data, url = os.getenv('SUPERPHY_RDF_URL', "http://localhost:9000/blaz
 	r = requests.post(url, payload)
 	return r.content
 
-#Example data_location: "file:////home/ubiquitin/Documents/Ontologies/RDF Schemas for the Project/owl.ttl"
-def file_update(data_location, url = os.getenv('SUPERPHY_RDF_URL', "http://localhost:9000/blazegraph")):
-	payload = {'uri': data_location}
-	r = requests.post(url, payload)
-	return r
-
-#These are example uses of these functions.
-
-#Note: Should printing really be in this file? Probably not
-'''
-#Quick debugging print function. Takes the object returned from bgquery, and the name of all variables you want to display from your query. Unfortunatly, you have to provide the names.
-def print_query(results,*args):
-	for result in results["results"]["bindings"]:
-		string = ""
-		for i, thing in enumerate(args):
-			string = string + result[thing]['value'] + " "
-		print string
-'''
-'''
-def print_spo(results):
-	print_query(results,"s","p","o")
-'''
+def file_update(path):
+	"""
+		Will upload the file at given abolute path
+	"""
+	return update("""LOAD <file:%s>;""" % (path))

--- a/venv/lib/python2.7/site-packages/superphy/upload/blazegraph_setup.py
+++ b/venv/lib/python2.7/site-packages/superphy/upload/blazegraph_setup.py
@@ -41,7 +41,7 @@ class BlazegraphSetup(object):
         Loads host category data from JSON into the rdflib.Graph()
 
         """
-        host_categories = self.import_json("data/host_categories.txt")
+        host_categories = import_json("data/host_categories.txt")
 
         for host_category in host_categories:
             name, label = host_category
@@ -55,7 +55,7 @@ class BlazegraphSetup(object):
         Loads host data from JSON into the rdflib.Graph()
 
         """
-        hosts = self.import_json("data/hosts.txt")
+        hosts = import_json("data/hosts.txt")
 
         for host in hosts:
             name, label, sci_name, com_name, host_category = host
@@ -69,7 +69,7 @@ class BlazegraphSetup(object):
         Loads isolation source data from JSON into the rdflib.Graph()
 
         """
-        sources = self.import_json("data/sources.txt")
+        sources = import_json("data/sources.txt")
 
         for source in sources:
             name, label, host_category = source
@@ -83,7 +83,7 @@ class BlazegraphSetup(object):
         Loads isolation syndrome data from JSON into the rdflib.Graph()
 
         """
-        syndromes = self.import_json("data/syndromes.txt")
+        syndromes = import_json("data/syndromes.txt")
 
         for syndrome in syndromes:
             name, label, host_category = syndrome
@@ -97,7 +97,7 @@ class BlazegraphSetup(object):
         Loads microbe data from JSON into the rdflib.Graph()
 
         """
-        microbes = self.import_json("data/microbes.txt")
+        microbes = import_json("data/microbes.txt")
 
         for microbe in microbes:
             name, label, sci_name, com_name = microbe
@@ -119,19 +119,7 @@ class BlazegraphSetup(object):
         Otype(self.g, "NT").rdf()
 
 
-    def import_json(self, filename):
-        """
-        Imports JSON data from the specified file into Python
 
-        Args:
-            filename (str): the relative filepath to this python function
-
-        Returns: a Python object composed of the data from the JSON data
-
-        """
-        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), filename)
-        with open(generate_path(path), "r+") as f:
-            return json.load(f)
 
 
     def setup_curated_data(self):
@@ -146,3 +134,17 @@ class BlazegraphSetup(object):
         self.convert_syndromes()
         self.generate_serotypes()
         generate_file_output(self.g, generate_path('ontologies/setup.ttl'))
+
+def import_json(filename):
+    """
+    Imports JSON data from the specified file into Python
+
+    Args:
+        filename (str): the relative filepath to this python function
+
+    Returns: a Python object composed of the data from the JSON data
+
+    """
+    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), filename)
+    with open(generate_path(path), "r+") as f:
+        return json.load(f)

--- a/venv/lib/python2.7/site-packages/superphy/upload/blazegraph_upload.py
+++ b/venv/lib/python2.7/site-packages/superphy/upload/blazegraph_upload.py
@@ -10,6 +10,7 @@ import os
 import requests
 
 from _utils import generate_path
+from superphy.shared.endpoint import file_update
 
 __author__ = "Stephen Kan"
 __copyright__ = "© Copyright Government of Canada 2012-2015. Funded by the Government of Canada Genomics Research and Development Initiative"
@@ -37,30 +38,16 @@ class BlazegraphUploader(object):
         """
         folder = generate_path("ontologies")
         files = os.listdir(folder)
-
         for file in files:
-            ontology = os.path.join(folder, file)
-            if file == "setup.ttl":
-                self.upload_file(ontology)
+            path = os.path.join(folder, file)
+            print "importing %s" % file
+            file_update(path)
 
     def upload_file(self, filepath):
         """
-        Upload a specified file onto Blazegraph.
-
-        The format of the file is automatically interpreted by Blazegraph based on the file extension. If any
-        format fails, it is probably because of an extension mismatch (for example, Turtle files are not .owl as the
-        WC3 standardized file format for RDF and OWL is RDF/XML.
-
-        Args:
-            filepath (str): relative filepath from this python script
-
-        Prints out the response object from Blazegraph
-
+            Relic - replaced by shared module
         """
-        file = "file:" + filepath
-        data = {'uri': file}
-        r = requests.post("http://localhost:9000/blazegraph", data)
-        return r.content
+        return endpoint.file_update(filepath)
 
     def upload_data(self, data):
         """Uploads raw data onto Blazegraph. To ensure that Blazegraph interprets properly, it is necessary to specify
@@ -78,15 +65,3 @@ class BlazegraphUploader(object):
         headers = {'Content-Type':'application/x-turtle'}
         r = requests.post(os.getenv('SUPERPHY_RDF_URL', "http://localhost:9000/blazegraph/namespace/superphy/sparql"), data=data, headers=headers)
         print r.content
-
-    def create_namespace(self):
-        """
-        Creates the superphy namespace based on the options in data/namespace.xml
-
-        Returns: the response object from superphy used for control flow
-
-        """
-        headers = {'Content-Type':'application/xml'}
-        data = "".join(line for line in open(generate_path("data/namespace.xml")))
-        r = requests.post(os.getenv('SUPERPHY_RDF_URL', "http://localhost:9000/blazegraph/namespace/superphy/sparql"), data=data, headers=headers)
-        return r.content

--- a/venv/lib/python2.7/site-packages/superphy/upload/tests/db_integration.py
+++ b/venv/lib/python2.7/site-packages/superphy/upload/tests/db_integration.py
@@ -30,6 +30,7 @@ class BlazegraphIntegration(object):
         
     @classmethod
     def tearDownClass(cls):
+        pass
         top_dir = generate_path("../../../../../../..")
         os.chdir(top_dir)
         src = os.path.join(os.getcwd(),"superphy/database/blazegraph/testing/bigdata.jnl")


### PR DESCRIPTION
Changed how files are uploaded to blazegraph.

Instead of using the file upload option, it uses the general option of using sparql update, with the command load file:...

This should fix the issues with uploading files to the new blazegraph 2.0.0

This is part of the series of updates resulting from switching to blazegraph 2.0.0